### PR TITLE
Fix netty dependencies

### DIFF
--- a/browserup-proxy-core/build.gradle
+++ b/browserup-proxy-core/build.gradle
@@ -57,7 +57,7 @@ uploadArchives {
 }
 
 dependencies {
-    api "io.netty:netty-codec:${nettyVersion}"
+    api "io.netty:netty-all:${nettyVersion}"
     api("xyz.rogfam:littleproxy:${littleProxyVersion}") {
         exclude(group: 'io.netty', module: 'netty-all')
     }
@@ -73,7 +73,6 @@ dependencies {
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation 'com.jcraft:jzlib:1.1.3'
     implementation 'dnsjava:dnsjava:3.3.1'
-    implementation "io.netty:netty-all:${nettyVersion}"
     implementation "org.bouncycastle:bcpkix-jdk15on:${bcpVersion}"
     implementation "org.bouncycastle:bcprov-jdk15on:${bcpVersion}"
     implementation 'org.brotli:dec:0.1.2'

--- a/browserup-proxy-mitm/build.gradle
+++ b/browserup-proxy-mitm/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk15on:${bcpVersion}"
 
     implementation "io.netty:netty-all:${nettyVersion}"
-    implementation "io.netty:netty-codec:${nettyVersion}"
     implementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     implementation("xyz.rogfam:littleproxy:${littleProxyVersion}") {


### PR DESCRIPTION
`netty-all` already includes `netty-codec` as a subset, there is no need to have extra dependency.