### PR TITLE
Bump jettyVersion from `9.4.45.v20220203` to `9.4.46.v20220331`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
         guiceVersion = '4.2.3'
         jacksonVersion = '2.13.2'
         javassistVersion = '3.28.0-GA'
-        jettyVersion = '9.4.45.v20220203'
+        jettyVersion = '9.4.46.v20220331'
         log4jVersion = '2.17.2'
         nettyVersion = '4.1.75.Final'
         littleProxyVersion = '2.0.7'


### PR DESCRIPTION
Bumps `jettyVersion` from 9.4.45.v20220203 to 9.4.46.v20220331

Updates `jetty-server` from 9.4.45.v20220203 to 9.4.46.v20220331
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](eclipse/jetty.project@jetty-9.4.45.v20220203...jetty-9.4.46.v20220331)

Updates `jetty-servlet` from 9.4.45.v20220203 to 9.4.46.v20220331
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](eclipse/jetty.project@jetty-9.4.45.v20220203...jetty-9.4.46.v20220331)

Updates `jetty-servlets` from 9.4.45.v20220203 to 9.4.46.v20220331
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](eclipse/jetty.project@jetty-9.4.45.v20220203...jetty-9.4.46.v20220331)

---
updated-dependencies:
- dependency-name: org.eclipse.jetty:jetty-server
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: org.eclipse.jetty:jetty-servlet
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: org.eclipse.jetty:jetty-servlets
  dependency-type: direct:production
  update-type: version-update:semver-major
...