### PR TITLE
Use the CONNECT method URI as host fallback

### DIFF
--- a/browserup-proxy-mitm/src/main/java/com/browserup/bup/util/HttpUtil.java
+++ b/browserup-proxy-mitm/src/main/java/com/browserup/bup/util/HttpUtil.java
@@ -33,17 +33,7 @@ public class HttpUtil {
             }
         }
 
-        // if there was no host in the URI, attempt to grab the host from the Host header
-        if (host == null || host.isEmpty()) {
-            host = parseHostHeader(httpRequest, false);
-        }
-
-        // if there was not a Host header, and the method is CONNECT, use that as the host
-        if (host == null || host.isEmpty()) {
-            host = hostFromConnect(httpRequest, false);
-        }
-
-        return host;
+        return parseHost(host, httpRequest, false);
     }
 
     /**
@@ -63,17 +53,7 @@ public class HttpUtil {
             }
         }
 
-        // if there was no host in the URI, attempt to grab the host from the Host header
-        if (host == null || host.isEmpty()) {
-            host = parseHostHeader(httpRequest, true);
-        }
-
-        // if there was not Host header, and the method is CONNECT, use that as the host
-        if (host == null || host.isEmpty()) {
-            host = hostFromConnect(httpRequest, true);
-        }
-
-        return host;
+        return parseHost(host, httpRequest, true);
     }
 
     /**
@@ -114,6 +94,20 @@ public class HttpUtil {
         }
     }
 
+    private static String parseHost(String host, HttpRequest httpRequest, boolean includePort) {
+        // if there was no host in the URI, attempt to grab the host from the Host header
+        if (isEmpty(host)) {
+            host = parseHostHeader(httpRequest, includePort);
+        }
+
+        // if there was not a Host header, and the method is CONNECT, use that as the host
+        if (isEmpty(host)) {
+            host = hostFromConnect(httpRequest, includePort);
+        }
+
+        return host;
+    }
+
     /**
      * Retrieves the host and, optionally, the port from the specified request's Host header.
      *
@@ -149,12 +143,14 @@ public class HttpUtil {
         if (HttpMethod.CONNECT.equals(httpRequest.method())) {
             if (includePort) {
                 return httpRequest.uri();
-            } else {
-                HostAndPort parsedHostAndPort = HostAndPort.fromString(httpRequest.uri());
-                return parsedHostAndPort.getHost();
             }
-        } else {
-            return null;
+            HostAndPort parsedHostAndPort = HostAndPort.fromString(httpRequest.uri());
+            return parsedHostAndPort.getHost();
         }
+        return null;
+    }
+
+    private static boolean isEmpty(String str) {
+        return str == null || str.isEmpty();
     }
 }

--- a/browserup-proxy-mitm/src/main/java/com/browserup/bup/util/HttpUtil.java
+++ b/browserup-proxy-mitm/src/main/java/com/browserup/bup/util/HttpUtil.java
@@ -2,6 +2,7 @@ package com.browserup.bup.util;
 
 import com.google.common.net.HostAndPort;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 
 import java.net.URI;
@@ -37,6 +38,11 @@ public class HttpUtil {
             host = parseHostHeader(httpRequest, false);
         }
 
+        // if there was not a Host header, and the method is CONNECT, use that as the host
+        if (host == null || host.isEmpty()) {
+            host = hostFromConnect(httpRequest, false);
+        }
+
         return host;
     }
 
@@ -48,15 +54,26 @@ public class HttpUtil {
      * @return host and port of the request
      */
     public static String getHostAndPortFromRequest(HttpRequest httpRequest) {
+        String host = null;
         if (startsWithHttpOrHttps(httpRequest.uri())) {
             try {
-                return getHostAndPortFromUri(httpRequest.uri());
+                host = getHostAndPortFromUri(httpRequest.uri());
             } catch (URISyntaxException e) {
                 // the URI could not be parsed, so return the host and port in the Host header
             }
         }
 
-        return parseHostHeader(httpRequest, true);
+        // if there was no host in the URI, attempt to grab the host from the Host header
+        if (host == null || host.isEmpty()) {
+            host = parseHostHeader(httpRequest, true);
+        }
+
+        // if there was not Host header, and the method is CONNECT, use that as the host
+        if (host == null || host.isEmpty()) {
+            host = hostFromConnect(httpRequest, true);
+        }
+
+        return host;
     }
 
     /**
@@ -114,6 +131,26 @@ public class HttpUtil {
                 return hostAndPort;
             } else {
                 HostAndPort parsedHostAndPort = HostAndPort.fromString(hostAndPort);
+                return parsedHostAndPort.getHost();
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves the host and, optionally, the port from the specified request's URI if the method is CONNECT.
+     *
+     * @param httpRequest HTTP request
+     * @param includePort when true, include the port
+     * @return the host and, optionally, the port specified in the request's URI
+     */
+    private static String hostFromConnect(HttpRequest httpRequest, boolean includePort) {
+        if (HttpMethod.CONNECT.equals(httpRequest.method())) {
+            if (includePort) {
+                return httpRequest.uri();
+            } else {
+                HostAndPort parsedHostAndPort = HostAndPort.fromString(httpRequest.uri());
                 return parsedHostAndPort.getHost();
             }
         } else {

--- a/browserup-proxy-mitm/src/test/java/com/browserup/bup/mitm/integration/LittleProxyIntegrationTest.java
+++ b/browserup-proxy-mitm/src/test/java/com/browserup/bup/mitm/integration/LittleProxyIntegrationTest.java
@@ -7,6 +7,7 @@ import io.netty.handler.codec.http.HttpResponse;
 import com.browserup.bup.mitm.manager.ImpersonatingMitmManager;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpVersion;
+import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -38,65 +39,16 @@ import static org.junit.Assert.assertTrue;
 public class LittleProxyIntegrationTest {
     @Test
     public void testLittleProxyMitm() throws IOException, InterruptedException {
-        final AtomicBoolean interceptedGetRequest = new AtomicBoolean();
-        final AtomicBoolean interceptedGetResponse = new AtomicBoolean();
-
-        HttpFiltersSource filtersSource = new HttpFiltersSourceAdapter() {
-            @Override
-            public HttpFilters filterRequest(HttpRequest originalRequest) {
-                return new HttpFiltersAdapter(originalRequest) {
-                    @Override
-                    public HttpResponse proxyToServerRequest(HttpObject httpObject) {
-                        if (httpObject instanceof HttpRequest) {
-                            HttpRequest httpRequest = (HttpRequest) httpObject;
-                            if (httpRequest.getMethod().equals(HttpMethod.GET)) {
-                                interceptedGetRequest.set(true);
-                            }
-                        }
-
-                        return super.proxyToServerRequest(httpObject);
-                    }
-
-                    @Override
-                    public HttpObject serverToProxyResponse(HttpObject httpObject) {
-                        if (httpObject instanceof HttpResponse) {
-                            HttpResponse httpResponse = (HttpResponse) httpObject;
-                            if (httpResponse.getStatus().code() == 200) {
-                                interceptedGetResponse.set(true);
-                            }
-                        }
-                        return super.serverToProxyResponse(httpObject);
-                    }
-                };
-            }
-        };
-
-        ImpersonatingMitmManager mitmManager = ImpersonatingMitmManager.builder().build();
-
-        HttpProxyServer proxyServer = DefaultHttpProxyServer.bootstrap()
-                .withPort(0)
-                .withManInTheMiddle(mitmManager)
-                .withFiltersSource(filtersSource)
-                .start();
-
-        try (CloseableHttpClient httpClient = getNewHttpClient(proxyServer.getListenAddress().getPort())) {
-            try (CloseableHttpResponse response = httpClient.execute(new HttpGet("https://www.google.com"))) {
-                assertEquals("Expected to receive an HTTP 200 from http://www.google.com", 200, response.getStatusLine().getStatusCode());
-
-                EntityUtils.consume(response.getEntity());
-            }
-        }
-
-        Thread.sleep(500);
-
-        assertTrue("Expected HttpFilters to successfully intercept the HTTP GET request", interceptedGetRequest.get());
-        assertTrue("Expected HttpFilters to successfully intercept the server's response to the HTTP GET", interceptedGetResponse.get());
-
-        proxyServer.abort();
+        testLittleProxyMitm(null);
     }
 
     @Test
     public void testLittleProxyMitmHttp1_0() throws IOException, InterruptedException {
+        testLittleProxyMitm(HttpVersion.HTTP_1_0);
+    }
+
+    private void testLittleProxyMitm(ProtocolVersion protocolVersion) throws IOException, InterruptedException
+    {
         final AtomicBoolean interceptedGetRequest = new AtomicBoolean();
         final AtomicBoolean interceptedGetResponse = new AtomicBoolean();
 
@@ -140,7 +92,7 @@ public class LittleProxyIntegrationTest {
 
         try (CloseableHttpClient httpClient = getNewHttpClient(proxyServer.getListenAddress().getPort())) {
             HttpGet httpGet = new HttpGet("https://www.google.com");
-            httpGet.setProtocolVersion(HttpVersion.HTTP_1_0);
+            httpGet.setProtocolVersion(protocolVersion);
             try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
                 assertEquals("Expected to receive an HTTP 200 from http://www.google.com", 200, response.getStatusLine().getStatusCode());
 


### PR DESCRIPTION
When a request is made for proxy interception using the `CONNECT` method but not including a `host` header, then a `NullPointerException` is thrown in `com.browserup.bup.mitm.manager.ImpersonatingMitmManager.getHostnameImpersonatingSslContext(String, SSLSession)` because the `hostnameToImpersonate` is null.

As a fallback, use the CONNECT URI as a host.

Submitted to the original proxy at https://github.com/browserup/browserup-proxy/pull/371