### PR TITLE
Drop Javassist dependency

### DIFF
--- a/browserup-proxy-core/build.gradle
+++ b/browserup-proxy-core/build.gradle
@@ -76,7 +76,6 @@ dependencies {
     implementation "org.bouncycastle:bcpkix-jdk15on:${bcpVersion}"
     implementation "org.bouncycastle:bcprov-jdk15on:${bcpVersion}"
     implementation 'org.brotli:dec:0.1.2'
-    implementation "org.javassist:javassist:${javassistVersion}"
     implementation "org.seleniumhq.selenium:selenium-api:${seleniumVersion}"
     implementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"

--- a/browserup-proxy-dist/build.gradle
+++ b/browserup-proxy-dist/build.gradle
@@ -77,7 +77,6 @@ dependencies {
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
     implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     implementation "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
-    implementation "org.javassist:javassist:${javassistVersion}"
 }
 
 applicationName = 'browserup-proxy'

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ subprojects {
         bcpVersion = '1.70'
         guiceVersion = '4.2.3'
         jacksonVersion = '2.13.3'
-        javassistVersion = '3.29.0-GA'
         jettyVersion = '9.4.46.v20220331'
         log4jVersion = '2.17.2'
         nettyVersion = '4.1.77.Final'


### PR DESCRIPTION
Javassist dependency was added in order to improve Netty performance: https://github.com/valfirst/browserup-proxy/commit/93f9f84ce5c8b1b526f6d59ef82abd908e5e86ac.
However Netty dropped Javassist support a long time ago: https://github.com/netty/netty/commit/7d08b4fc357e12ee2487e87d8fdcbeee1152e5a0.