### PR TITLE
Fix Falcon deprecation warnings

### DIFF
--- a/browserup-proxy-core/src/main/resources/mitmproxy/bu_addons_manager.py
+++ b/browserup-proxy-core/src/main/resources/mitmproxy/bu_addons_manager.py
@@ -56,7 +56,7 @@ def get_resources():
 
 
 def start_falcon(resources):
-    app = falcon.API()
+    app = falcon.App()
     for resource in resources:
         app.add_route("/" + resource.addon_path() + "/{method_name}", resource)
 

--- a/browserup-proxy-core/src/main/resources/mitmproxy/har_dump.py
+++ b/browserup-proxy-core/src/main/resources/mitmproxy/har_dump.py
@@ -104,7 +104,7 @@ class HarDumpAddonResource:
 
         resp.status = falcon.HTTP_200
         resp.content_type = falcon.MEDIA_JSON
-        resp.body = json.dumps({
+        resp.text = json.dumps({
             "path": har_file.name,
             "json": filtered_har
         }, ensure_ascii=False)
@@ -118,7 +118,7 @@ class HarDumpAddonResource:
         har_file = self.harDumpAddOn.save_har(har)
 
         resp.status = falcon.HTTP_200
-        resp.body = json.dumps({
+        resp.text = json.dumps({
             "path": har_file.name,
             "json": har
         }, ensure_ascii=False)
@@ -129,7 +129,7 @@ class HarDumpAddonResource:
         har_file = self.harDumpAddOn.save_har(har)
 
         resp.status = falcon.HTTP_200
-        resp.body = json.dumps({
+        resp.text = json.dumps({
             "path": har_file.name,
             "json": har
         }, ensure_ascii=False)
@@ -143,7 +143,7 @@ class HarDumpAddonResource:
         har_file = self.harDumpAddOn.save_har(har)
 
         resp.status = falcon.HTTP_200
-        resp.body = json.dumps({
+        resp.text = json.dumps({
             "path": har_file.name,
             "json": har
         }, ensure_ascii=False)
@@ -154,7 +154,7 @@ class HarDumpAddonResource:
         har_file = self.harDumpAddOn.save_har(har)
 
         resp.status = falcon.HTTP_200
-        resp.body = json.dumps({
+        resp.text = json.dumps({
             "path": har_file.name,
             "json": har
         }, ensure_ascii=False)
@@ -171,7 +171,7 @@ class HarDumpAddonResource:
 
             if not hasattr(HarCaptureTypes, ct):
                 resp.status = falcon.HTTP_400
-                resp.body = "Invalid HAR Capture type"
+                resp.text = "Invalid HAR Capture type"
                 return
 
             capture_types_parsed.append(HarCaptureTypes[ct])

--- a/browserup-proxy-core/src/main/resources/mitmproxy/proxy_manager.py
+++ b/browserup-proxy-core/src/main/resources/mitmproxy/proxy_manager.py
@@ -50,7 +50,7 @@ class ProxyManagerResource:
         getattr(self, "on_" + method_name)(req, resp)
 
     def on_health_check(self, req, resp):
-        resp.body = 'OK'
+        resp.text = 'OK'
         resp.status = falcon.HTTP_200
 
     def on_trust_all(self, req, resp):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mitmproxy==6.0.2
 markupsafe==2.0.1
 python-dateutil
-falcon
+falcon >= 3


### PR DESCRIPTION
- Fixed deprecation warnings:
  1. `DeprecatedWarning: Call to deprecated function __init__(...). API class may be removed in a future release, use falcon.App instead.
  api = falcon.API()`
  1. `DeprecatedWarning: Call to deprecated property body. Please use text instead.`
- Explicitly require `falcon >= 3`