### PR TITLE
Bump jettyVersion from `9.4.46.v20220331` to `9.4.48.v20220622`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
         bcpVersion = '1.70'
         guiceVersion = '4.2.3'
         jacksonVersion = '2.13.3'
-        jettyVersion = '9.4.46.v20220331'
+        jettyVersion = '9.4.48.v20220622'
         log4jVersion = '2.17.2'
         nettyVersion = '4.1.78.Final'
         littleProxyVersion = '2.0.9'


### PR DESCRIPTION
Bumps `jettyVersion` from 9.4.46.v20220331 to 9.4.48.v20220622

Updates `jetty-server` from 9.4.46.v20220331 to 9.4.48.v20220622
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](eclipse/jetty.project@jetty-9.4.46.v20220331...eclipse/jetty-9.4.48.v20220622)

Updates `jetty-servlet` from 9.4.46.v20220331 to 9.4.48.v20220622
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](eclipse/jetty.project@jetty-9.4.46.v20220331...eclipse/jetty-9.4.48.v20220622)

Updates `jetty-servlets` from 9.4.46.v20220331 to 9.4.48.v20220622
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](eclipse/jetty.project@jetty-9.4.46.v20220331...eclipse/jetty-9.4.48.v20220622)

---
updated-dependencies:
- dependency-name: org.eclipse.jetty:jetty-server
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: org.eclipse.jetty:jetty-servlet
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: org.eclipse.jetty:jetty-servlets
  dependency-type: direct:production
  update-type: version-update:semver-major
...