### PR TITLE
Bump Jetty from `9.4.48.v20220622` to `9.4.49.v20220914`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ subprojects {
         guiceVersion = '4.2.3'
         jacksonVersion = '2.13.4'
         jerseyVersion = '2.32'
-        jettyVersion = '9.4.48.v20220622'
+        jettyVersion = '9.4.49.v20220914'
         log4jVersion = '2.19.0'
         nettyVersion = '4.1.82.Final'
         littleProxyVersion = '2.0.11'


### PR DESCRIPTION
Bumps `jettyVersion` from 9.4.48.v20220622 to 9.4.49.v20220914.

Updates `jetty-server` from 9.4.48.v20220622 to 9.4.49.v20220914
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](eclipse/jetty.project@jetty-9.4.48.v20220622...jetty-9.4.49.v20220914)

Updates `jetty-servlet` from 9.4.48.v20220622 to 9.4.49.v20220914
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](eclipse/jetty.project@jetty-9.4.48.v20220622...jetty-9.4.49.v20220914)

Updates `jetty-servlets` from 9.4.48.v20220622 to 9.4.49.v20220914
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](eclipse/jetty.project@jetty-9.4.48.v20220622...jetty-9.4.49.v20220914)

---
updated-dependencies:
- dependency-name: org.eclipse.jetty:jetty-server dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.eclipse.jetty:jetty-servlet dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.eclipse.jetty:jetty-servlets dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: Valery Yatsynovich <valery_yatsynovich@epam.com>