### PR TITLE
Start deprecating copy-pasted HAR reader logic

### DIFF
--- a/browserup-proxy-core/build.gradle
+++ b/browserup-proxy-core/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.10.0"
     implementation 'org.zeroturnaround:zt-exec:1.12'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'de.sstoehr:har-reader:2.2.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.codehaus.groovy:groovy-all:3.0.13'
     testImplementation "org.apache.logging.log4j:log4j-api:${log4jVersion}"

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/HarReader.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/HarReader.java
@@ -8,6 +8,10 @@ import com.browserup.harreader.model.Har;
 import java.io.File;
 import java.io.IOException;
 
+/**
+ * @deprecated Use {@link de.sstoehr.harreader.HarReader}
+ */
+@Deprecated
 public class HarReader {
 
     private final MapperFactory mapperFactory;

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/HarReaderException.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/HarReaderException.java
@@ -1,5 +1,9 @@
 package com.browserup.harreader;
 
+/**
+ * @deprecated Use {@link de.sstoehr.harreader.HarReaderException}
+ */
+@Deprecated
 public class HarReaderException extends Exception {
 
     public HarReaderException(Throwable cause) {

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/HarReaderMode.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/HarReaderMode.java
@@ -1,5 +1,9 @@
 package com.browserup.harreader;
 
+/**
+ * @deprecated Use {@link de.sstoehr.harreader.HarReaderMode}
+ */
+@Deprecated
 public enum HarReaderMode {
 
     /**

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/jackson/DefaultMapperFactory.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/jackson/DefaultMapperFactory.java
@@ -6,7 +6,11 @@ import com.browserup.harreader.HarReaderMode;
 
 import java.util.Date;
 
-public class DefaultMapperFactory implements MapperFactory {
+/**
+ * @deprecated Use {@link de.sstoehr.harreader.jackson.DefaultMapperFactory}
+ */
+@Deprecated
+public class DefaultMapperFactory extends de.sstoehr.harreader.jackson.DefaultMapperFactory implements MapperFactory {
 
     @Override
     public ObjectMapper instance(HarReaderMode mode) {

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/jackson/ExceptionIgnoringDateDeserializer.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/jackson/ExceptionIgnoringDateDeserializer.java
@@ -1,24 +1,9 @@
 package com.browserup.harreader.jackson;
 
-import java.io.IOException;
-import java.util.Date;
-
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.std.DateDeserializers;
-
-public class ExceptionIgnoringDateDeserializer extends JsonDeserializer<Date> {
-
-    @Override
-    public Date deserialize(JsonParser jp, DeserializationContext ctxt) throws java.io.IOException {
-        try {
-            DateDeserializers.DateDeserializer dateDeserializer = new DateDeserializers.DateDeserializer();
-            return dateDeserializer.deserialize(jp, ctxt);
-        } catch (IOException e) {
-            //ignore
-        }
-        return new Date(0L);
-    }
+/**
+ * @deprecated Use {@link de.sstoehr.harreader.jackson.ExceptionIgnoringDateDeserializer}
+ */
+@Deprecated
+public class ExceptionIgnoringDateDeserializer extends de.sstoehr.harreader.jackson.ExceptionIgnoringDateDeserializer {
 
 }

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/jackson/ExceptionIgnoringIntegerDeserializer.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/jackson/ExceptionIgnoringIntegerDeserializer.java
@@ -1,21 +1,9 @@
 package com.browserup.harreader.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.std.NumberDeserializers;
+/**
+ * @deprecated Use {@link de.sstoehr.harreader.jackson.ExceptionIgnoringIntegerDeserializer}
+ */
+@Deprecated
+public class ExceptionIgnoringIntegerDeserializer extends de.sstoehr.harreader.jackson.ExceptionIgnoringIntegerDeserializer {
 
-import java.io.IOException;
-
-public class ExceptionIgnoringIntegerDeserializer extends JsonDeserializer<Integer> {
-    @Override
-    public Integer deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-        try {
-            NumberDeserializers.IntegerDeserializer integerDeserializer = new NumberDeserializers.IntegerDeserializer(Integer.class, null);
-            return integerDeserializer.deserialize(jp, ctxt);
-        } catch (IOException e) {
-            //ignore
-        }
-        return null;
-    }
 }

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/jackson/MapperFactory.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/jackson/MapperFactory.java
@@ -3,7 +3,11 @@ package com.browserup.harreader.jackson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.browserup.harreader.HarReaderMode;
 
-public interface MapperFactory {
+/**
+ * @deprecated Use {@link de.sstoehr.harreader.jackson.MapperFactory}
+ */
+@Deprecated
+public interface MapperFactory extends de.sstoehr.harreader.jackson.MapperFactory {
 
     ObjectMapper instance(HarReaderMode mode);
 

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/model/HarHeader.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/model/HarHeader.java
@@ -1,67 +1,9 @@
 package com.browserup.harreader.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-import java.util.Objects;
-
 /**
- * Information about a header used in request and/or response.
- * @see <a href="http://www.softwareishard.com/blog/har-12-spec/#headers">specification</a>
+ * @deprecated Use {@link de.sstoehr.harreader.model.HarHeader}
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class HarHeader {
+@Deprecated
+public class HarHeader extends de.sstoehr.harreader.model.HarHeader {
 
-    private String name;
-    private String value;
-    private String comment;
-
-    /**
-     * @return Header name, null if not present.
-     */
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    /**
-     * @return Header value, null if not present.
-     */
-    public String getValue() {
-        return value;
-    }
-
-    public void setValue(String value) {
-        this.value = value;
-    }
-
-    /**
-     * @return Comment provided by the user or application, null if not present.
-     */
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        HarHeader harHeader = (HarHeader) o;
-        return Objects.equals(name, harHeader.name) &&
-                Objects.equals(value, harHeader.value) &&
-                Objects.equals(comment, harHeader.comment);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, value, comment);
-    }
 }

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/model/HarPageTiming.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/model/HarPageTiming.java
@@ -1,77 +1,9 @@
 package com.browserup.harreader.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-import java.util.Objects;
-
 /**
- * Information about events occurring during page load.
- * @see <a href="http://www.softwareishard.com/blog/har-12-spec/#pageTimings">specification</a>
+ * @deprecated Use {@link de.sstoehr.harreader.model.HarPageTiming}
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class HarPageTiming {
+@Deprecated
+public class HarPageTiming extends de.sstoehr.harreader.model.HarPageTiming {
 
-    protected static final Integer DEFAULT_TIME = -1;
-
-    private Integer onContentLoad = DEFAULT_TIME;
-    private Integer onLoad = DEFAULT_TIME;
-    private String comment;
-
-    /**
-     * @return Duration in ms until content is loaded.
-     * {@link #DEFAULT_TIME} when no information available.
-     */
-    public Integer getOnContentLoad() {
-        if (onContentLoad == null) {
-            return DEFAULT_TIME;
-        }
-        return onContentLoad;
-    }
-
-    public void setOnContentLoad(Integer onContentLoad) {
-        this.onContentLoad = onContentLoad;
-    }
-
-    /**
-     * @return Duration in ms until onLoad event is fired.
-     * {@link #DEFAULT_TIME} when no information available.
-     */
-    public Integer getOnLoad() {
-        if (onLoad == null) {
-            return DEFAULT_TIME;
-        }
-        return onLoad;
-    }
-
-    public void setOnLoad(Integer onLoad) {
-        this.onLoad = onLoad;
-    }
-
-    /**
-     * @return Comment provided by the user or application, null if not present.
-     */
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        HarPageTiming that = (HarPageTiming) o;
-        return Objects.equals(onContentLoad, that.onContentLoad) &&
-                Objects.equals(onLoad, that.onLoad) &&
-                Objects.equals(comment, that.comment);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(onContentLoad, onLoad, comment);
-    }
 }

--- a/browserup-proxy-core/src/main/java/com/browserup/harreader/model/HarQueryParam.java
+++ b/browserup-proxy-core/src/main/java/com/browserup/harreader/model/HarQueryParam.java
@@ -1,67 +1,9 @@
 package com.browserup.harreader.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-
-import java.util.Objects;
-
 /**
- * Information about query params.
- * @see <a href="http://www.softwareishard.com/blog/har-12-spec/#queryString">specification</a>
+ * Use {@link de.sstoehr.harreader.model.HarQueryParam}
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class HarQueryParam {
+@Deprecated
+public class HarQueryParam extends de.sstoehr.harreader.model.HarQueryParam {
 
-    private String name;
-    private String value;
-    private String comment;
-
-    /**
-     * @return Name of param, null if not present.
-     */
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    /**
-     * @return Value of param, null if not present.
-     */
-    public String getValue() {
-        return value;
-    }
-
-    public void setValue(String value) {
-        this.value = value;
-    }
-
-    /**
-     * @return Comment provided by the user or application, null if not present.
-     */
-    public String getComment() {
-        return comment;
-    }
-
-    public void setComment(String comment) {
-        this.comment = comment;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        HarQueryParam that = (HarQueryParam) o;
-        return Objects.equals(name, that.name) &&
-                Objects.equals(value, that.value) &&
-                Objects.equals(comment, that.comment);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, value, comment);
-    }
 }


### PR DESCRIPTION
At some point the full copy of HAR reader library (https://github.com/sdstoehr/har-reader) was added to BrowserUp proxy: https://github.com/browserup/browserup-proxy/pull/38/. That was not a good solution, since the fixes from the original library are not added back, the copy adds extra maintenance effort, etc. The best strategy here is to propose custom changes to the original implementation step by step.

This commit starts the deprecation process of copy-pasted as-is HAR reader entities.