### PR TITLE
Revert "Bump netty-all from 4.1.82.Final to 4.1.84.Final (#156)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ subprojects {
         jerseyVersion = '2.32'
         jettyVersion = '9.4.49.v20220914'
         log4jVersion = '2.19.0'
-        nettyVersion = '4.1.84.Final'
+        nettyVersion = '4.1.82.Final'
         littleProxyVersion = '2.0.13'
         slf4jVersion = '2.0.3'
         swaggerVersion = '2.2.6'


### PR DESCRIPTION
This reverts commit 743c4a5605f13cd6c66b3000fb6f944e992384a5.

Closes https://github.com/valfirst/browserup-proxy/issues/160