### PR TITLE
Fixes #177 don't use Jackson BOM as explicit dependency

### DIFF
--- a/browserup-proxy-core/build.gradle
+++ b/browserup-proxy-core/build.gradle
@@ -64,10 +64,9 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
     implementation 'org.awaitility:awaitility:4.2.0'
-    implementation platform('com.fasterxml.jackson:jackson-bom:2.14.0')
-    implementation 'com.fasterxml.jackson.core:jackson-core'
-    implementation 'com.fasterxml.jackson.core:jackson-databind'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
 
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation 'com.jcraft:jzlib:1.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ subprojects {
     ext {
         bcpVersion = '1.72'
         guiceVersion = '4.2.3'
+        jacksonVersion = '2.14.1'
         jerseyVersion = '2.32'
         jettyVersion = '9.4.49.v20220914'
         log4jVersion = '2.19.0'


### PR DESCRIPTION
Fixes #177

in Jackson BOM documentation it's clearly said:

> NOTE: BOM can NOT be used as an explicit dependency; it MUST be either parent pom or imported in section