### PR TITLE
Fix scope of `jcl-over-slf4j`  dependency

### DIFF
--- a/browserup-proxy-core/build.gradle
+++ b/browserup-proxy-core/build.gradle
@@ -75,7 +75,6 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk18on:${bcpVersion}"
     implementation 'org.brotli:dec:0.1.2'
     implementation "org.seleniumhq.selenium:selenium-api:${seleniumVersion}"
-    implementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'org.zeroturnaround:zt-exec:1.12'
@@ -85,6 +84,7 @@ dependencies {
     testImplementation "org.apache.logging.log4j:log4j-api:${log4jVersion}"
     testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
     testImplementation "org.apache.logging.log4j:log4j-slf4j2-impl:${log4jVersion}"
+    testImplementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     testImplementation 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
     testImplementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     testImplementation "org.eclipse.jetty:jetty-servlet:${jettyVersion}"

--- a/browserup-proxy-mitm/build.gradle
+++ b/browserup-proxy-mitm/build.gradle
@@ -59,7 +59,6 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk18on:${bcpVersion}"
 
     implementation "io.netty:netty-all:${nettyVersion}"
-    implementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     implementation("xyz.rogfam:littleproxy:${littleProxyVersion}") {
         exclude(group: 'io.netty', module: 'netty-all')
@@ -72,6 +71,7 @@ dependencies {
     testImplementation "org.apache.logging.log4j:log4j-api:${log4jVersion}"
     testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
     testImplementation "org.apache.logging.log4j:log4j-slf4j2-impl:${log4jVersion}"
+    testImplementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     testImplementation 'org.codehaus.groovy:groovy-all:3.0.19'
     testImplementation "org.hamcrest:hamcrest:${hamcrestVersion}"
     testImplementation 'org.mockito:mockito-core:4.11.0'

--- a/browserup-proxy-rest/build.gradle
+++ b/browserup-proxy-rest/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     implementation "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
-    implementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     implementation 'org.apache.commons:commons-lang3:3.13.0'
 
     implementation "org.glassfish.jersey.containers:jersey-container-servlet-core:${jerseyVersion}"
@@ -87,6 +86,7 @@ dependencies {
     testImplementation "org.apache.logging.log4j:log4j-api:${log4jVersion}"
     testImplementation "org.apache.logging.log4j:log4j-core:${log4jVersion}"
     testImplementation "org.apache.logging.log4j:log4j-slf4j2-impl:${log4jVersion}"
+    testImplementation "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
     testImplementation 'org.codehaus.groovy:groovy-all:3.0.19'
     testImplementation 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
     testImplementation "org.hamcrest:hamcrest:${hamcrestVersion}"


### PR DESCRIPTION
Let users decide which logging framework to use and how to bridge Jakarta Commons Logging (JCL)