### PR TITLE
[CI] Use `setup-gradle` action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,9 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
-        cache: 'gradle'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5


### PR DESCRIPTION
- https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#why-use-the-setup-gradle-action
- https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms