### PR TITLE
Drop `jzlib` dependency

### DIFF
--- a/browserup-proxy-core/build.gradle
+++ b/browserup-proxy-core/build.gradle
@@ -72,7 +72,6 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
 
     implementation "com.google.guava:guava:${guavaVersion}"
-    implementation 'com.jcraft:jzlib:1.1.3'
     implementation "org.bouncycastle:bcpkix-jdk18on:${bcpVersion}"
     implementation "org.bouncycastle:bcprov-jdk18on:${bcpVersion}"
     implementation 'org.brotli:dec:0.1.2'


### PR DESCRIPTION
Originally `jzlib` depdency was added to support defalte decompression, this library was optional in netty: https://github.com/lightbody/browsermob-proxy/pull/225/files. 
Over time JDK zlib decompression support was added to netty: https://github.com/netty/netty/issues/1481. And then this implemnetation became default: https://github.com/netty/netty/issues/4707. 
It makes `jzlib` dependency redundant, as JDK based implmentation is used. If someone needs to use `jzlib` dependency, then it's required to set the corresponding netty flag and to add this library explicitly to the local project dependencies.