### PR TITLE
Drop `guice-multibindings` dependency

### DIFF
--- a/browserup-proxy-dist/build.gradle
+++ b/browserup-proxy-dist/build.gradle
@@ -66,10 +66,10 @@ dependencies {
 
     implementation "com.google.inject:guice:${guiceVersion}"
     implementation "com.google.inject.extensions:guice-servlet:${guiceVersion}"
-    implementation "com.google.inject.extensions:guice-multibindings:${guiceVersion}"
     implementation('com.google.sitebricks:sitebricks:0.8.11') {
         exclude(group: 'org.jboss.netty', module: 'netty')
         exclude(module: 'validation-api')
+        exclude(group: 'com.google.inject.extensions', module: 'guice-multibindings')
     }
     implementation "io.netty:netty-all:${nettyVersion}"
     implementation "org.apache.logging.log4j:log4j-api:${log4jVersion}"

--- a/browserup-proxy-rest-clients/build.gradle
+++ b/browserup-proxy-rest-clients/build.gradle
@@ -117,9 +117,10 @@ dependencies {
 
     testImplementation "com.google.inject:guice:$guiceVersion"
     testImplementation "com.google.inject.extensions:guice-servlet:$guiceVersion"
-    testImplementation "com.google.inject.extensions:guice-multibindings:$guiceVersion"
 
-    testImplementation 'com.google.sitebricks:sitebricks:0.8.11'
+    testImplementation('com.google.sitebricks:sitebricks:0.8.11') {
+        exclude(group: 'com.google.inject.extensions', module: 'guice-multibindings')
+    }
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.apache.logging.log4j:log4j-api:${log4jVersion}"

--- a/browserup-proxy-rest/build.gradle
+++ b/browserup-proxy-rest/build.gradle
@@ -63,10 +63,10 @@ dependencies {
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation "com.google.inject:guice:${guiceVersion}"
     implementation "com.google.inject.extensions:guice-servlet:${guiceVersion}"
-    implementation "com.google.inject.extensions:guice-multibindings:${guiceVersion}"
     implementation('com.google.sitebricks:sitebricks:0.8.11') {
         exclude(group: 'org.jboss.netty', module: 'netty')
         exclude(module: 'validation-api')
+        exclude(group: 'com.google.inject.extensions', module: 'guice-multibindings')
     }
     implementation "io.netty:netty-all:${nettyVersion}"
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'


### PR DESCRIPTION
Since Guice 4.2, multibindings support has moved to Guice core: https://github.com/google/guice/wiki/Guice42#changes-since-guice-42.