### PR TITLE
Bump org.openapi.generator from 4.3.1 to 5.4.0

### DIFF
--- a/browserup-proxy-rest-clients/build.gradle
+++ b/browserup-proxy-rest-clients/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id "io.swagger.core.v3.swagger-gradle-plugin" version "${swaggerVersion}"
-    id 'org.openapi.generator' version '4.3.1'
+    id 'org.openapi.generator' version '5.4.0'
 }
 
 archivesBaseName = 'browserup-proxy-rest-clients'


### PR DESCRIPTION
Bumps org.openapi.generator from 4.3.1 to 5.4.0.

---
updated-dependencies:
- dependency-name: org.openapi.generator dependency-type: direct:production update-type: version-update:semver-major ...